### PR TITLE
Updated Anno 1800 IDs

### DIFF
--- a/ubisoft/v1/products.jsonc
+++ b/ubisoft/v1/products.jsonc
@@ -64,7 +64,6 @@
       12173, // LanguagePackKorean
       12174, // LanguagePackChinese
       12175, // LanguagePackTaiwanese
-      12176,
       14074, // Anno 1800 - Season Pass Player Assets
       14214, // Anno 1800 DLC - Sunken Treasure
       14215, // Anno 1800 DLC - Botanica
@@ -103,9 +102,9 @@
       17811, // Anno 1800 - Twitch Drop - HighLife 2
       // 17878, // Uplay - Free Weekend - Feb 2021
       // 17879, // Epic - Free Weekend - Feb 2021
-      59682,
       59720, // Anno 1800 - Anno 1701 - Ship Skin
-      59721 // Anno 1800 - Anno 2070 - Ship Skin
+      59721, // Anno 1800 - Anno 2070 - Ship Skin
+      60682 //Anno 1800 DLC - Sesional Decorations (CDLC07)
     ],
     "items": []
   },

--- a/ubisoft/v1/products.jsonc
+++ b/ubisoft/v1/products.jsonc
@@ -64,6 +64,7 @@
       12173, // LanguagePackKorean
       12174, // LanguagePackChinese
       12175, // LanguagePackTaiwanese
+      12176, // This ID does not exist in game files but unlocker DLL says it's called in by the game
       14074, // Anno 1800 - Season Pass Player Assets
       14214, // Anno 1800 DLC - Sunken Treasure
       14215, // Anno 1800 DLC - Botanica
@@ -102,9 +103,10 @@
       17811, // Anno 1800 - Twitch Drop - HighLife 2
       // 17878, // Uplay - Free Weekend - Feb 2021
       // 17879, // Epic - Free Weekend - Feb 2021
+      59682, // This ID does not exist in game files but unlocker DLL says it's called in by the game
       59720, // Anno 1800 - Anno 1701 - Ship Skin
       59721, // Anno 1800 - Anno 2070 - Ship Skin
-      60682 //Anno 1800 DLC - Sesional Decorations (CDLC07)
+      60682 //Anno 1800 DLC - Sesional Decorations (CDLC07) (Also known as "Seasonal Decorations Pack" in the stores)
     ],
     "items": []
   },


### PR DESCRIPTION
Added Anno 1800 ID:
      60682 //Anno 1800 DLC - Sesional Decorations (CDLC07)

Removed Anno 1800 IDs that don't exist in game files:
      12176,
      59682,